### PR TITLE
Allow defusedxml>=0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'lxml >= 3.5.0, < 3.7',
-        'defusedxml >= 0.4.1, < 0.5',
+        'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.4',
         'cryptography >= 1.2.3, < 1.8',
         'pyOpenSSL >= 0.15.1, < 17',


### PR DESCRIPTION
defusedxml 0.5 has been released, and has almost no changes (only adding support for Python 3.6 with minimal code change, dropping support for older Python versions, and updating a unit test). This PR starts allowing versions 0.5 and above (up to but not including 0.6) to be used to satisfy the defusedxml requirements. This is especially useful for projects where signxml is used with other projects that required defusedxml >= 0.5 (such as python-social-auth's social-core).